### PR TITLE
procd: jail/jail: correctly check for null pointer

### DIFF
--- a/jail/jail.c
+++ b/jail/jail.c
@@ -215,6 +215,10 @@ static void free_hooklist(struct hook_execvpe **hooklist)
 
 static void free_sysctl(void) {
 	struct sysctl_val *cur;
+
+	if (!opts.sysctl)
+		return;
+
 	cur = *opts.sysctl;
 
 	while (cur) {


### PR DESCRIPTION
Handle case where opts.sysctl is not used.

Signed-off-by: Philipp Meier <philipp.meier@westermo.com>